### PR TITLE
feat: added qty for duplicate products

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -216,7 +216,7 @@
 
         // Insert a cell at the end of the row
         let newCell = newRow.insertCell();
-        newCell.innerHTML = `<div class='cartinfo' data-aos='fade-up'><img src='${item.img}' /><div><p>${item.productName}</p><small>Price: Rs. ${item.productPrice}</small><br /><span class="remove-btn" id="remove-${id}" onclick="removeItem()">Remove</span></div></div>`;
+        newCell.innerHTML = `<div class='cartinfo' data-aos='fade-up'><img src='${item.img}' /><div><p>${item.productName}</p><small>Size: ${item.productSize}, Price: ${item.productPrice} Rs.</small><br /><span class="remove-btn" id="remove-${id}" onclick="removeItem()">Remove</span></div></div>`;
 
         newCell = newRow.insertCell();
         newCell.innerHTML += `<input type='number' value='${item.productQuantity}' data-aos="fade-up" onchange="updateQty(this)" id="updateQty-${id}" min="1"/>`;

--- a/productdetail.html
+++ b/productdetail.html
@@ -263,11 +263,8 @@
         let productQuantity = parseFloat(
           document.getElementById("productQuantity").value
         );
+        let isProductDuplicate = false;
         let id = 0;
-        let checkUser = JSON.parse(localStorage.getItem("user"));
-        if (checkUser) {
-          id = checkUser.cart.length;
-        }
         let product = {
           id,
           img: img.src,
@@ -280,7 +277,15 @@
         userString2 = localStorage.getItem("user");
         const retrievedUser = JSON.parse(userString2);
         console.log("user after retrieving: ", retrievedUser);
-        retrievedUser.cart.push(product);
+
+        retrievedUser.cart.forEach(cartItem => {
+          if(cartItem.id === product.id && cartItem.productSize === product.productSize) {
+            cartItem.productQuantity = +cartItem.productQuantity + +product.productQuantity
+            isProductDuplicate = true;
+          }
+        })
+        if(!isProductDuplicate) retrievedUser.cart.push(product);
+        
         console.log("user after updating: ", retrievedUser);
         const updatedUserString = JSON.stringify(retrievedUser);
         localStorage.setItem("user", updatedUserString);


### PR DESCRIPTION
Issue: #60 

# Why?
While adding the same product(with the same size) to the cart, it's creating a duplicate entry on the cart page with no size information.

# What? 

- Updated the productQuantity when the same item is added (only when id and productSize are the same) -- for grouping the same products.
For eg, if the cart has: Shirt with 1 Qty, -> after adding the same product -> it'll update the quantity to 2.
- Added product size info on the card page, to distinguish between two similar products.

# Updated Screenshot:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/46138150/193833387-d7aab798-93b6-441e-a006-8b62f059fd0f.png">

# Deployed link: 
### https://helpful-pixie-1ec1c0.netlify.app/
