### PR TITLE
fix cart icon in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -1141,6 +1141,7 @@ body.active {
 
 .cart-image.bgm-change {
     background-color: white;
+    filter: invert(100%);
 }
 
 


### PR DESCRIPTION
Added filter to icon's img in dark mode. 
![image](https://user-images.githubusercontent.com/10657720/196010743-46a4460e-43c1-4cb6-8b48-2938d04a0df8.png)
